### PR TITLE
Fix issue when multiple forms

### DIFF
--- a/extensions/theme-extension/assets/app-block.js
+++ b/extensions/theme-extension/assets/app-block.js
@@ -45,6 +45,10 @@
       return this.subscriptionWidgetContainer.getAttribute('data-section-id');
     }
 
+    get productId() {
+      return this.subscriptionWidgetContainer.getAttribute('data-product-id');
+    }
+
     get shopifySection() {
       return document.querySelector(`#shopify-section-${this.sectionId}`);
     }
@@ -83,7 +87,15 @@
     }
 
     get addToCartForms() {
-      return this.shopifySection.querySelectorAll('[action*="/cart/add"]');
+      /** 
+       * A section might contain multiple forms, some unrelated to the product represented by this widget. This is frequent
+       * for instance in the product section containing a complementary product blocks with quick buy. Each complementary product
+       * quick buy will have its own form, so we need to filter them. By default, the {% form 'product' %} Liquid tag will add the
+       * "product-id" attribute, so we can filter the forms that are not related to the product represented by this widget.
+       */
+      const forms = Array.from(this.shopifySection.querySelectorAll('[action*="/cart/add"]'));
+
+      return forms.filter((form) => form.elements['product-id']?.value === this.productId);
     }
 
     appendSellingPlanInputs() {

--- a/extensions/theme-extension/assets/app-block.js
+++ b/extensions/theme-extension/assets/app-block.js
@@ -95,7 +95,7 @@
        */
       const forms = Array.from(this.shopifySection.querySelectorAll('[action*="/cart/add"]'));
 
-      return forms.filter((form) => form.elements['product-id']?.value === this.productId);
+      return forms.filter((form) => form.elements['product-id'] === undefined || form.elements['product-id']?.value === this.productId);
     }
 
     appendSellingPlanInputs() {

--- a/extensions/theme-extension/blocks/app-block.liquid
+++ b/extensions/theme-extension/blocks/app-block.liquid
@@ -4,7 +4,7 @@
 %}
 
 {% if product.selling_plan_groups.size > 0 %}
-  <div class="shopify_subscriptions_app_container" data-section-id='{{ section.id }}'>
+  <div class="shopify_subscriptions_app_container" data-section-id='{{ section.id }}' data-product-id='{{ product.id }}'>
     <script src="{{ 'app-block.js' | asset_url }}" defer></script>
     <link href="{{ 'styles.css' | asset_url }}" rel='stylesheet' type="text/css"/>
     {% for variant in product.variants %}


### PR DESCRIPTION
Hello,

This PR fixes a critical issue in the current implementation to make it more defensive. The code currently naively get all the forms inside a section, ignoring whether they relate to the actual product represented by the widget or not. This is actually causing issues in all our themes, that offer a complementary product block to show complementary products inside the product section. Due to the fact that all our themes have quick buy feature, this means that each product in the complementary product section also have its own forms.

Because Shopify code did not filter them, you end up with multiple forms in the `addToCartForms` that do not relate to the actual product, which cause issue in the `variantIdInput`, as it will get the variant ID related to a product that is not managed by the widget itself.

This PR takes advantage of the fact that the `{% form 'product' %}` automatically outputs a `product-id` hidden attribute, which allows us to only keep the relevant forms and exclude the ones that do not refer to the managed product. This will solve the problem for all our themes, and for all themes that are using the {% form 'product' %} (normally, everybody).

In case a theme don't use the Liquid tag and generate by themselve a manual form, it won't have a `product-id` attribute. For those, the form won't be filtered and will be returned, hence ensuring we don't break compatibility.