### PR TITLE
Avoid npx in shopify.web.toml

### DIFF
--- a/shopify.web.toml
+++ b/shopify.web.toml
@@ -1,7 +1,0 @@
-name = "remix"
-roles = ["frontend", "backend"]
-webhooks_path = "/webhooks/cli"
-
-[commands]
-predev = "npx dotenv -c development npm run setup"
-dev = "npx remix vite:dev"

--- a/shopify.web.toml.liquid
+++ b/shopify.web.toml.liquid
@@ -1,0 +1,11 @@
+name = "remix"
+roles = ["frontend", "backend"]
+webhooks_path = "/webhooks/cli"
+
+{%- assign exec = dependency_manager | append: ' exec' -%}
+{%- if dependency_manager == 'yarn' -%}
+{%- assign exec = 'yarn' -%}
+{%- endif %}
+[commands]
+predev = "{{ exec }} dotenv -c development npm run setup"
+dev = "{{ exec }} remix vite:dev"


### PR DESCRIPTION
### WHY are these changes introduced?

We are hardcoding `npx` in the shopify.web.toml and it causes `shopify app dev` to fail when it's not available.

### WHAT is this pull request doing?

Run the commands using the current package manager of the project

### Test this PR

```bash
shopify app init --template=https://github.com/Shopify/subscriptions-reference-app#remove-npx
shopify app dev
```